### PR TITLE
fix: ensure profile row before photo upload

### DIFF
--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -55,6 +55,7 @@ export default function ProfilePage() {
 
   const [profilo, setProfilo] = useState(null);
   const [userId, setUserId] = useState(null);
+  const [userEmail, setUserEmail] = useState("");
 
   const [name, setName] = useState("");
   const [bio, setBio] = useState("");
@@ -92,6 +93,7 @@ export default function ProfilePage() {
 
         if (!user?.id) {
           setUserId(null);
+          setUserEmail("");
           setProfilo(null);
           setName("");
           setBio("");
@@ -101,6 +103,7 @@ export default function ProfilePage() {
         }
 
         setUserId(user.id);
+        setUserEmail(user.email || "");
 
         const { data: profileData, error: profileError } = await supabase
           .from("profili")
@@ -169,6 +172,40 @@ export default function ProfilePage() {
 
   const isPremium = useMemo(() => hasCommercialPremium(profilo), [profilo]);
 
+  const ensureProfileRow = async () => {
+    if (!userId) {
+      throw new Error("Utente non autenticato.");
+    }
+
+    const payload = {
+      id: userId,
+      email: profilo?.email || userEmail || "",
+      nome: name.trim(),
+      bio: bio.trim(),
+      interessi: interests.trim(),
+      updated_at: new Date().toISOString(),
+    };
+
+    const { data, error } = await supabase
+      .from("profili")
+      .upsert(payload, { onConflict: "id" })
+      .select("id, nome, email, bio, interessi, foto_url, avatar_url, ruolo, premium, premium_start, premium_fine, tipo_abbonamento, status_account")
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    const nextProfile = data || {
+      ...(profilo || {}),
+      ...payload,
+    };
+
+    setProfilo(nextProfile);
+
+    return nextProfile;
+  };
+
   const handleAddPhoto = () => {
     const input = document.getElementById("profile-photo-input");
     input?.click();
@@ -190,7 +227,13 @@ export default function ProfilePage() {
     try {
       setUploading(true);
 
+      await ensureProfileRow();
+
+
+
       const currentPhotos = [...photos];
+
+
       const rowsToInsert = [];
 
       for (const file of filesToUse) {
@@ -337,6 +380,7 @@ export default function ProfilePage() {
 
       const payload = {
         id: userId,
+        email: profilo?.email || userEmail || "",
         nome: name.trim(),
         bio: bio.trim(),
         interessi: interests.trim(),

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -305,6 +305,21 @@ export default function ProfilePage() {
         order: index,
       }));
 
+      const tempOrderOffset = 1000;
+
+      for (const [index, item] of normalizedOrder.entries()) {
+        const { error } = await supabase
+          .from("profili_foto")
+          .update({
+            is_primary: false,
+            ordine: tempOrderOffset + index,
+          })
+          .eq("id", item.id)
+          .eq("profilo_id", userId);
+
+        if (error) throw error;
+      }
+
       for (const item of normalizedOrder) {
         const { error } = await supabase
           .from("profili_foto")


### PR DESCRIPTION
## Cosa cambia

Corregge il bug in /profilo dove l'upload foto falliva per gli utenti autenticati senza riga profilo già presente in public.profili.

## Problema

L'insert su public.profili_foto falliva con errore FK:

- profili_foto.profilo_id_fkey
- profilo_id non presente in public.profili

## Soluzione

Prima dell'insert in profili_foto, ProfilePage assicura la presenza della riga profilo tramite upsert su public.profili.

## Sicurezza

- Non scrive campi sensibili come ruolo, premium o status_account dal client.
- Non modifica policy Supabase.
- Non modifica DNS, Vercel o env.
- Mantiene RLS owner-scoped su profili_foto.

## File modificato

- src/pages/ProfilePage.jsx

## Test eseguiti

- Verifica strutturale payload: OK
- npm run build: OK
- npm audit --omit=dev: 0 vulnerabilities
- Branch pushato: OK

## Test da eseguire in preview

- Login QA
- /profilo
- Upload 2 immagini QA
- Gallery 2/5
- Imposta principale
- Rimuovi entrambe
- Gallery 0/5
- Console senza errori rossi app