### PR TITLE
fix: keep profile photo ordering within range

### DIFF
--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -290,50 +290,36 @@ export default function ProfilePage() {
     try {
       setSaving(true);
 
-      const reordered = photos.map((item, index) => {
-        if (item.id === photoId) {
-          return { ...item, isPrimary: true, order: 0 };
-        }
-        return { ...item, isPrimary: false, order: index + 1 };
-      });
-
-      const primary = reordered.find((item) => item.id === photoId);
-      const rest = reordered.filter((item) => item.id !== photoId);
-      const normalizedOrder = [primary, ...rest].filter(Boolean).map((item, index) => ({
-        ...item,
-        isPrimary: index === 0,
-        order: index,
-      }));
-
-      const tempOrderOffset = 1000;
-
-      for (const [index, item] of normalizedOrder.entries()) {
-        const { error } = await supabase
-          .from("profili_foto")
-          .update({
-            is_primary: false,
-            ordine: tempOrderOffset + index,
-          })
-          .eq("id", item.id)
-          .eq("profilo_id", userId);
-
-        if (error) throw error;
+      const selectedExists = photos.some((item) => item.id === photoId);
+      if (!selectedExists) {
+        toast.error("Foto non trovata.");
+        return;
       }
 
-      for (const item of normalizedOrder) {
-        const { error } = await supabase
-          .from("profili_foto")
-          .update({
-            is_primary: item.isPrimary,
-            ordine: item.order,
-          })
-          .eq("id", item.id)
-          .eq("profilo_id", userId);
+      const { error: resetError } = await supabase
+        .from("profili_foto")
+        .update({ is_primary: false })
+        .eq("profilo_id", userId);
 
-        if (error) throw error;
-      }
+      if (resetError) throw resetError;
 
-      setPhotos(normalizedOrder);
+      const { error: primaryError } = await supabase
+        .from("profili_foto")
+        .update({ is_primary: true })
+        .eq("id", photoId)
+        .eq("profilo_id", userId);
+
+      if (primaryError) throw primaryError;
+
+      const { data: refreshed, error: refreshError } = await supabase
+        .from("profili_foto")
+        .select("id, foto_url, ordine, is_primary, created_at")
+        .eq("profilo_id", userId)
+        .order("ordine", { ascending: true });
+
+      if (refreshError) throw refreshError;
+
+      setPhotos(normalizePhotos(refreshed || []));
       toast.success("✨ Foto principale aggiornata");
     } catch (error) {
       console.error("Errore foto principale:", error);
@@ -365,12 +351,32 @@ export default function ProfilePage() {
 
       if (refreshError) throw refreshError;
 
-      const normalized = normalizePhotos(refreshed || []);
+      const orderedRows = [...(refreshed || [])].sort((a, b) => {
+        return (a.ordine ?? 99) - (b.ordine ?? 99);
+      });
 
-      if (normalized.length > 0 && !normalized.some((item) => item.isPrimary)) {
-        normalized[0] = { ...normalized[0], isPrimary: true, order: 0 };
+      for (const [index, row] of orderedRows.entries()) {
+        const { error: reorderError } = await supabase
+          .from("profili_foto")
+          .update({
+            ordine: index,
+            is_primary: index === 0,
+          })
+          .eq("id", row.id)
+          .eq("profilo_id", userId);
+
+        if (reorderError) throw reorderError;
       }
 
+      const { data: compacted, error: compactedError } = await supabase
+        .from("profili_foto")
+        .select("id, foto_url, ordine, is_primary, created_at")
+        .eq("profilo_id", userId)
+        .order("ordine", { ascending: true });
+
+      if (compactedError) throw compactedError;
+
+      const normalized = normalizePhotos(compacted || []);
       setPhotos(normalized);
       toast.success("🗑️ Foto rimossa");
     } catch (error) {


### PR DESCRIPTION
## Cosa cambia

Corregge il cambio foto principale evitando ordini temporanei fuori range.

## Problema

In produzione, cliccando “Metti al centro” sulla seconda foto, Supabase rispondeva:

- 400 Bad Request
- profili_foto_ordine_range

Il precedente fix usava un ordine temporaneo 1000, ma il database accetta solo ordini nel range consentito.

## Soluzione

- “Metti al centro” aggiorna solo is_primary.
- Non modifica più ordine durante il cambio principale.
- La rimozione foto compatta gli ordini rimasti nel range 0,1,2...
- Se restano foto dopo delete, la prima viene impostata come principale.

## Sicurezza

- Nessuna modifica Supabase.
- Nessuna modifica env.
- Nessuna modifica DNS/Vercel.
- Mantiene RLS owner-scoped su profili_foto.

## File modificato

- src/pages/ProfilePage.jsx

## Test eseguiti

- npm run build: OK
- npm audit --omit=dev: 0 vulnerabilities
- git diff --check: OK
- push branch: OK

## Test da eseguire in preview

- Aprire preview lm360-admin-prod
- Login QA
- /profilo
- Con 2 foto QA presenti: cliccare “Metti al centro”
- Verificare nessun profili_foto_ordine_range
- Rimuovere entrambe le foto
- Verificare 0/5
- Console pulita